### PR TITLE
feat(AllTrails): tracking disable + heatmap proxy patches

### DIFF
--- a/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/heatmap/Fingerprints.kt
+++ b/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/heatmap/Fingerprints.kt
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2026 Hoo-dles
+ * https://github.com/hoo-dles/morphe-patches
+ */
+
+package hoodles.morphe.patches.alltrails.heatmap
+
+import app.morphe.patcher.Fingerprint
+
+internal const val ALLTRAILS_HEATMAP_PATH =
+    "/wmts/static/heatmaps/all/years_1/{z}/{x}/{y}.png"
+
+internal const val ALLTRAILS_HEATMAP_HOST_SUFFIX =
+    ".alltrails.com/wmts/static/heatmaps/all/years_1/{z}/{x}/{y}.png"
+
+internal const val DEFAULT_HEATMAP_TILE_URL_TEMPLATE =
+    "https://tiles.example.ts.net/tiles/years_1/all/{z}/{x}/{y}.png"
+
+internal object HeatmapTilePathFingerprint : Fingerprint(
+    strings = listOf(ALLTRAILS_HEATMAP_PATH)
+)
+
+internal object HeatmapTileHostSuffixFingerprint : Fingerprint(
+    strings = listOf(ALLTRAILS_HEATMAP_HOST_SUFFIX)
+)

--- a/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/heatmap/ProxyHeatmapPatch.kt
+++ b/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/heatmap/ProxyHeatmapPatch.kt
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2026 Hoo-dles
+ * https://github.com/hoo-dles/morphe-patches
+ */
+
+package hoodles.morphe.patches.alltrails.heatmap
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.stringOption
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import hoodles.morphe.patches.alltrails.shared.Constants
+import java.net.URI
+import java.util.logging.Logger
+
+private fun isValidHeatmapTileUrlTemplate(value: String): Boolean {
+    if (!value.startsWith("https://") && !value.startsWith("http://")) {
+        return false
+    }
+    if (!value.contains("{z}") || !value.contains("{x}") || !value.contains("{y}")) {
+        return false
+    }
+    return try {
+        val uri = URI(value.replace("{z}", "0").replace("{x}", "0").replace("{y}", "0"))
+        !uri.host.isNullOrBlank()
+    } catch (_: Exception) {
+        false
+    }
+}
+
+private fun MutableMethod.overwriteHeatmapUrlAfterToString(proxyUrl: String): Boolean {
+    val instructions = implementation?.instructions ?: return false
+    var replaced = false
+
+    val toStringMoveResultIndices = mutableListOf<Int>()
+    for (index in instructions.indices) {
+        val instruction = instructions[index]
+        if (instruction.opcode != Opcode.INVOKE_VIRTUAL) continue
+
+        val reference = (instruction as? ReferenceInstruction)?.reference as? MethodReference
+            ?: continue
+        if (reference.definingClass != "Ljava/lang/StringBuilder;") continue
+        if (reference.name != "toString") continue
+
+        val moveResultIndex = index + 1
+        if (moveResultIndex >= instructions.size) continue
+        if (instructions[moveResultIndex].opcode != Opcode.MOVE_RESULT_OBJECT) continue
+
+        toStringMoveResultIndices += moveResultIndex
+    }
+
+    for (moveResultIndex in toStringMoveResultIndices.asReversed()) {
+        val register = getInstruction<OneRegisterInstruction>(moveResultIndex).registerA
+        addInstructions(
+            moveResultIndex + 1,
+            """
+            const-string v$register, "$proxyUrl"
+            """.trimIndent()
+        )
+        replaced = true
+    }
+
+    return replaced
+}
+
+@Suppress("unused")
+val proxyHeatmapPatch = bytecodePatch(
+    name = "Proxy heatmap tiles",
+    description = "Optional. Rewrites AllTrails community heatmap tile URL templates to a " +
+        "configurable proxy (default Tailscale host). " +
+        "Off by default — enable explicitly. Unrelated AllTrails API hosts are left unchanged.",
+    default = false
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    val heatmapTileUrlTemplate by stringOption(
+        key = "heatmapTileUrlTemplate",
+        default = DEFAULT_HEATMAP_TILE_URL_TEMPLATE,
+        title = "Heatmap tile URL template",
+        description = "Full tile URL template including {z}/{x}/{y} placeholders. " +
+            "Example: https://tiles.example.ts.net/tiles/years_1/all/{z}/{x}/{y}.png",
+        required = true,
+        validator = { value ->
+            value != null && isValidHeatmapTileUrlTemplate(value)
+        }
+    )
+
+    execute {
+        val logger = Logger.getLogger("ProxyHeatmapPatch")
+        val proxyUrl = heatmapTileUrlTemplate
+            ?: error("Heatmap tile URL template is required")
+
+        if (!isValidHeatmapTileUrlTemplate(proxyUrl)) {
+            error(
+                "Invalid heatmap tile URL template. Provide an http(s) URL containing {z}, {x}, and {y}."
+            )
+        }
+
+        if ('"' in proxyUrl || '\\' in proxyUrl) {
+            error("Heatmap tile URL template must not contain quotes or backslashes")
+        }
+
+        fun applyProxyUrl(fingerprint: Fingerprint, label: String) {
+            val matches = fingerprint.matchAllOrNull()
+            if (matches.isNullOrEmpty()) {
+                logger.warning("No matches for $label; skipping")
+                return
+            }
+
+            var applied = 0
+            matches.forEach { match ->
+                if (match.method.overwriteHeatmapUrlAfterToString(proxyUrl)) {
+                    applied++
+                } else {
+                    logger.warning(
+                        "Matched $label in ${match.method} but could not overwrite StringBuilder result"
+                    )
+                }
+            }
+            logger.info("Proxy heatmap: applied $label to $applied method(s)")
+        }
+
+        applyProxyUrl(HeatmapTilePathFingerprint, "heatmap path builder")
+        applyProxyUrl(HeatmapTileHostSuffixFingerprint, "heatmap host-suffix builder")
+    }
+}

--- a/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/shared/Constants.kt
+++ b/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/shared/Constants.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Hoo-dles
+ * https://github.com/hoo-dles/morphe-patches
+ */
+
+package hoodles.morphe.patches.alltrails.shared
+
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+internal object Constants {
+    val COMPATIBILITY = Compatibility(
+        name = "AllTrails",
+        packageName = "com.alltrails.alltrails",
+        appIconColor = 0x64F67A,
+        targets = listOf(
+            AppTarget("26.3.20"),
+            AppTarget("26.6.20"),
+            AppTarget("26.7.40", isExperimental = true)
+        )
+    )
+}

--- a/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/tracking/DisableTrackingPatch.kt
+++ b/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/tracking/DisableTrackingPatch.kt
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2026 Hoo-dles
+ * https://github.com/hoo-dles/morphe-patches
+ */
+
+package hoodles.morphe.patches.alltrails.tracking
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.util.returnEarly
+import hoodles.morphe.patches.alltrails.shared.Constants
+import java.util.logging.Logger
+
+private fun MutableMethod.returnThis() {
+    addInstructions(0, "return-object p0")
+}
+
+@Suppress("unused")
+val disableTrackingPatch = bytecodePatch(
+    name = "Disable tracking and analytics",
+    description = "Disables non-essential third-party tracking and analytics SDKs " +
+        "(Amplitude, AppsFlyer, Braze, Firebase Analytics, Mapbox telemetry) while leaving " +
+        "core mapping, GPS recording, login, and sync intact. Firebase Crashlytics is left " +
+        "enabled. Braze marketing push / in-app messages may stop working.",
+    default = false
+) {
+    compatibleWith(Constants.COMPATIBILITY)
+
+    execute {
+        val logger = Logger.getLogger("DisableTrackingPatch")
+        val blocked = mutableListOf<String>()
+
+        fun tryBlock(sdk: String, fingerprintMethod: MutableMethod?, block: (MutableMethod) -> Unit) {
+            if (fingerprintMethod == null) {
+                logger.warning("Could not find $sdk hook; skipping")
+                return
+            }
+            if (fingerprintMethod.implementation == null) {
+                logger.warning("Skipping $sdk hook: method has no implementation (abstract/native)")
+                return
+            }
+            try {
+                block(fingerprintMethod)
+                blocked.add(sdk)
+            } catch (error: Exception) {
+                logger.warning("Failed to apply $sdk hook: ${error.message}")
+            }
+        }
+
+        tryBlock("AppsFlyer.isStopped", AppsFlyerIsStoppedFingerprint.methodOrNull) {
+            it.returnEarly(true)
+        }
+        tryBlock("AppsFlyer.init", AppsFlyerInitFingerprint.methodOrNull) {
+            it.returnThis()
+        }
+
+        tryBlock("Amplitude.logEvent", AmplitudeLogEventFingerprint.methodOrNull) {
+            it.returnEarly()
+        }
+        tryBlock("AmplitudeClient.logEvent", AmplitudeClientLogEventFingerprint.methodOrNull) {
+            it.returnEarly()
+        }
+        tryBlock("AmplitudeClient.initialize", AmplitudeClientInitializeFingerprint.methodOrNull) {
+            it.returnThis()
+        }
+
+        tryBlock("FirebaseAnalytics.logEvent", FirebaseAnalyticsLogEventFingerprint.methodOrNull) {
+            it.returnEarly()
+        }
+        tryBlock(
+            "FirebaseAnalytics.setAnalyticsCollectionEnabled",
+            FirebaseAnalyticsSetCollectionEnabledFingerprint.methodOrNull
+        ) {
+            it.returnEarly()
+        }
+
+        tryBlock("Braze.logCustomEvent", BrazeLogCustomEventFingerprint.methodOrNull) {
+            it.returnEarly()
+        }
+        tryBlock("Braze.openSession", BrazeOpenSessionFingerprint.methodOrNull) {
+            it.returnEarly()
+        }
+
+        tryBlock("Mapbox TelemetryUtils.initialize", MapboxTelemetryInitializeFingerprint.methodOrNull) {
+            it.returnEarly()
+        }
+        tryBlock("Mapbox onAppUserTurnstileEvent", MapboxTurnstileFingerprint.methodOrNull) {
+            it.returnEarly()
+        }
+        tryBlock("Mapbox sendMapLoadEvent", MapboxMapLoadEventFingerprint.methodOrNull) {
+            it.returnEarly()
+        }
+
+        if (blocked.isEmpty()) {
+            logger.warning("No tracking SDK hooks applied")
+        } else {
+            logger.info("Disabled tracking hooks: ${blocked.joinToString(", ")}")
+        }
+    }
+}

--- a/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/tracking/Fingerprints.kt
+++ b/patches/src/main/kotlin/hoodles/morphe/patches/alltrails/tracking/Fingerprints.kt
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2026 Hoo-dles
+ * https://github.com/hoo-dles/morphe-patches
+ */
+
+package hoodles.morphe.patches.alltrails.tracking
+
+import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+private const val APPS_FLYER_LIB = "Lcom/appsflyer/AppsFlyerLib;"
+
+internal object AppsFlyerIsStoppedFingerprint : Fingerprint(
+    name = "isStopped",
+    returnType = "Z",
+    parameters = emptyList(),
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    custom = { _, classDef -> classDef.superclass == APPS_FLYER_LIB }
+)
+
+internal object AppsFlyerInitFingerprint : Fingerprint(
+    name = "init",
+    returnType = APPS_FLYER_LIB,
+    parameters = listOf(
+        "Ljava/lang/String;",
+        "Lcom/appsflyer/AppsFlyerConversionListener;",
+        "Landroid/content/Context;"
+    ),
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    custom = { _, classDef -> classDef.superclass == APPS_FLYER_LIB }
+)
+
+internal object AmplitudeLogEventFingerprint : Fingerprint(
+    definingClass = "Lcom/amplitude/api/Amplitude;",
+    name = "logEvent",
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;")
+)
+
+internal object AmplitudeClientLogEventFingerprint : Fingerprint(
+    definingClass = "Lcom/amplitude/api/AmplitudeClient;",
+    name = "logEvent",
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;")
+)
+
+internal object AmplitudeClientInitializeFingerprint : Fingerprint(
+    definingClass = "Lcom/amplitude/api/AmplitudeClient;",
+    name = "initialize",
+    returnType = "Lcom/amplitude/api/AmplitudeClient;",
+    parameters = listOf("Landroid/content/Context;", "Ljava/lang/String;")
+)
+
+internal object FirebaseAnalyticsLogEventFingerprint : Fingerprint(
+    definingClass = "Lcom/google/firebase/analytics/FirebaseAnalytics;",
+    name = "logEvent",
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;", "Landroid/os/Bundle;")
+)
+
+internal object FirebaseAnalyticsSetCollectionEnabledFingerprint : Fingerprint(
+    definingClass = "Lcom/google/firebase/analytics/FirebaseAnalytics;",
+    name = "setAnalyticsCollectionEnabled",
+    returnType = "V",
+    parameters = listOf("Z")
+)
+
+internal object BrazeLogCustomEventFingerprint : Fingerprint(
+    definingClass = "Lcom/braze/Braze;",
+    name = "logCustomEvent",
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;", "Lcom/braze/models/outgoing/BrazeProperties;")
+)
+
+internal object BrazeOpenSessionFingerprint : Fingerprint(
+    definingClass = "Lcom/braze/Braze;",
+    name = "openSession",
+    returnType = "V",
+    parameters = listOf("Landroid/app/Activity;")
+)
+
+internal object MapboxTelemetryInitializeFingerprint : Fingerprint(
+    definingClass = "Lcom/mapbox/common/TelemetryUtils;",
+    name = "initialize",
+    returnType = "V",
+    parameters = emptyList()
+)
+
+internal object MapboxTurnstileFingerprint : Fingerprint(
+    definingClass = "Lcom/mapbox/maps/module/telemetry/MapTelemetryImpl;",
+    name = "onAppUserTurnstileEvent",
+    returnType = "V",
+    parameters = emptyList()
+)
+
+internal object MapboxMapLoadEventFingerprint : Fingerprint(
+    definingClass = "Lcom/mapbox/maps/module/telemetry/MapTelemetryImpl;",
+    name = "sendMapLoadEvent",
+    returnType = "V",
+    parameters = emptyList()
+)


### PR DESCRIPTION
## Summary
- Adds two optional AllTrails patches for **26.3.20**, **26.6.20**, and experimental **26.7.40**:
  - **Disable tracking and analytics** — no-ops Amplitude, AppsFlyer, Braze, Firebase Analytics, and Mapbox telemetry calls (Crashlytics left enabled).
  - **Proxy heatmap tiles** — rewrites community heatmap tile URL templates to a configurable proxy URL (default example Tailscale host). Off by default. Fixes https://github.com/hoo-dles/morphe-patches/issues/510#issuecomment-4749001074 with an optional paid proxy. 
- Adds `alltrails/shared/Constants.kt` with shared compatibility targets.

## Test plan
- [ ] `./gradlew :patches:compileKotlin` passes
- [ ] Patch AllTrails 26.6.20 with both patches enabled and verify heatmap tiles hit the proxy URL
- [ ] Patch AllTrails 26.7.40 and confirm tracking hooks apply without breaking login/sync