### PR TITLE
feat(hellochinese): add Skip on first mistake lesson patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.44.0](https://github.com/OmerKurdi79/morphe-patches/compare/v1.43.0...v1.44.0) (2026-09-02)
+
+
+### Features
+
+* **hellochinese:** add Skip on first mistake lesson patch ([e6dc1f7](https://github.com/OmerKurdi79/morphe-patches/commit/e6dc1f7f31700dbd4712ab1364c273e3a5907706))
+
 # [1.43.0](https://github.com/hoo-dles/morphe-patches/compare/v1.42.0...v1.43.0) (2026-08-30)
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.43.0
+version = 1.44.0

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-08-30T00:31:23",
-  "description": "# [1.43.0](https://github.com/hoo-dles/morphe-patches/compare/v1.42.0...v1.43.0) (2026-08-30)\n\n\n### Bug Fixes\n\n* **AdGuard:** Add version code for correct APK discovery ([d08ac92](https://github.com/hoo-dles/morphe-patches/commit/d08ac92d55211c5b9faef91d94245cd076ed0550))\n* **Niagara:** Bump supported version to `1.16.24` and fix patch failure ([d2344ae](https://github.com/hoo-dles/morphe-patches/commit/d2344ae2726b5ab5f7e14fa75e52d0990a8a22e5))\n* **Showly:** Fix news feed not loading ([828698e](https://github.com/hoo-dles/morphe-patches/commit/828698efb3ece50b5e07a9cc8dcc4c4d3b1490e0))\n\n\n### Features\n\n* **Bend:** Add `Enable Premium` patch ([d3ee74f](https://github.com/hoo-dles/morphe-patches/commit/d3ee74f73ad1239cb580a485e1c0bc97ab0510f1))",
-  "download_url": "https://github.com/hoo-dles/morphe-patches/releases/download/v1.43.0/patches-1.43.0.mpp",
-  "signature_download_url": "https://github.com/hoo-dles/morphe-patches/releases/download/v1.43.0/patches-1.43.0.mpp.asc",
-  "version": "1.43.0"
+  "created_at": "2026-09-02T09:40:52",
+  "description": "# [1.44.0](https://github.com/OmerKurdi79/morphe-patches/compare/v1.43.0...v1.44.0) (2026-09-02)\n\n\n### Features\n\n* **hellochinese:** add Skip on first mistake lesson patch ([e6dc1f7](https://github.com/OmerKurdi79/morphe-patches/commit/e6dc1f7f31700dbd4712ab1364c273e3a5907706))",
+  "download_url": "https://github.com/OmerKurdi79/morphe-patches/releases/download/v1.44.0/patches-1.44.0.mpp",
+  "signature_download_url": "https://github.com/OmerKurdi79/morphe-patches/releases/download/v1.44.0/patches-1.44.0.mpp.asc",
+  "version": "1.44.0"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "patches": [
     {
       "name": "AMOLED dark theme",
@@ -826,34 +826,6 @@
       "default": true,
       "dependencies": [
         "RawResourcePatch"
-      ],
-      "compatiblePackages": [
-        {
-          "packageName": "com.hellochinese",
-          "name": "HelloChinese",
-          "description": null,
-          "apkFileType": null,
-          "appIconColor": "#FFFFFF",
-          "signatures": null,
-          "targets": [
-            {
-              "version": "7.11.0",
-              "versionCodes": null,
-              "isExperimental": false,
-              "minSdk": null,
-              "description": null
-            }
-          ]
-        }
-      ],
-      "options": []
-    },
-    {
-      "name": "Skip on first mistake",
-      "description": "Shows both skip and continue buttons from the first mistake.",
-      "default": true,
-      "dependencies": [
-        "BytecodePatch"
       ],
       "compatiblePackages": [
         {
@@ -2032,6 +2004,34 @@
           "targets": [
             {
               "version": "3.0.452.1047",
+              "versionCodes": null,
+              "isExperimental": false,
+              "minSdk": null,
+              "description": null
+            }
+          ]
+        }
+      ],
+      "options": []
+    },
+    {
+      "name": "Skip on first mistake",
+      "description": "Shows both skip and continue buttons from the first mistake.",
+      "default": true,
+      "dependencies": [
+        "BytecodePatch"
+      ],
+      "compatiblePackages": [
+        {
+          "packageName": "com.hellochinese",
+          "name": "HelloChinese",
+          "description": null,
+          "apkFileType": null,
+          "appIconColor": "#FFFFFF",
+          "signatures": null,
+          "targets": [
+            {
+              "version": "7.11.0",
               "versionCodes": null,
               "isExperimental": false,
               "minSdk": null,

--- a/patches-list.json
+++ b/patches-list.json
@@ -849,6 +849,34 @@
       "options": []
     },
     {
+      "name": "Skip on first mistake",
+      "description": "Shows both skip and continue buttons from the first mistake.",
+      "default": true,
+      "dependencies": [
+        "BytecodePatch"
+      ],
+      "compatiblePackages": [
+        {
+          "packageName": "com.hellochinese",
+          "name": "HelloChinese",
+          "description": null,
+          "apkFileType": null,
+          "appIconColor": "#FFFFFF",
+          "signatures": null,
+          "targets": [
+            {
+              "version": "7.11.0",
+              "versionCodes": null,
+              "isExperimental": false,
+              "minSdk": null,
+              "description": null
+            }
+          ]
+        }
+      ],
+      "options": []
+    },
+    {
       "name": "Enable Premium",
       "description": "Enables app features locked behind the subscription paywall.",
       "default": true,

--- a/patches/src/main/kotlin/hoodles/morphe/patches/hellochinese/lesson/Fingerprints.kt
+++ b/patches/src/main/kotlin/hoodles/morphe/patches/hellochinese/lesson/Fingerprints.kt
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2026 Hoo-dles
+ * https://github.com/hoo-dles/morphe-patches
+ */
+
+package hoodles.morphe.patches.hellochinese.lesson
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.OpcodesFilter
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+
+private const val HC3_BASE_LESSON_ACTIVITY_CLASS =
+    "Lcom/hellochinese/lesson/activitys/HC3BaseLessonActivity;"
+
+/**
+ * Matches HC3BaseLessonActivity.V0() method.
+ *
+ * The method's bytecode pattern:
+ *   invoke-super {p0}, BasicLessonActivity;->V0()V
+ *   iget-boolean v0, p0, HC3BaseLessonActivity;->r2:Z
+ *   if-eqz v0, :cond_0
+ *   iget-object v0, p0, BasicLessonActivity;->P:Lx1/c;
+ *   invoke-interface {v0}, Lx1/c;->getCurrentQuestionWrongTime()I
+ *   move-result v0
+ *   const/4 v1, 0x3          <-- this is the threshold we want to change
+ *   if-lt v0, v1, :cond_0
+ */
+internal object SkipOnFirstMistakeFingerprint : Fingerprint(
+    definingClass = HC3_BASE_LESSON_ACTIVITY_CLASS,
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    returnType = "V",
+    parameters = listOf(),
+    filters = OpcodesFilter.opcodesToFilters(
+        Opcode.INVOKE_SUPER,
+        Opcode.IGET_BOOLEAN,
+        Opcode.IF_EQZ,
+        Opcode.IGET_OBJECT,
+        Opcode.INVOKE_INTERFACE,
+        Opcode.MOVE_RESULT,
+        Opcode.CONST_4,
+        Opcode.IF_LT,
+    )
+)
+
+/**
+ * Matches CheckPanel.h() method — and ONLY h(), not resetView().
+ *
+ * h() is exactly 7 instructions ending in RETURN_VOID:
+ *   iget-object v0, p0, CheckPanel;->mContinueBtnLayout
+ *   const/16 v1, 0x8
+ *   invoke-virtual {v0, v1}, View;->setVisibility(I)V
+ *   iget-object v0, p0, CheckPanel;->skpiLayout
+ *   const/4 v1, 0x0
+ *   invoke-virtual {v0, v1}, View;->setVisibility(I)V
+ *   return-void
+ *
+ * resetView() starts with the same 6 opcodes but continues with more
+ * instructions before returning, so including RETURN_VOID disambiguates.
+ */
+internal object CheckPanelHMethodFingerprint : Fingerprint(
+    definingClass = "Lcom/hellochinese/views/widgets/CheckPanel;",
+    accessFlags = listOf(AccessFlags.PUBLIC),
+    returnType = "V",
+    parameters = listOf(),
+    filters = OpcodesFilter.opcodesToFilters(
+        Opcode.IGET_OBJECT,
+        Opcode.CONST_16,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.IGET_OBJECT,
+        Opcode.CONST_4,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.RETURN_VOID,
+    )
+)

--- a/patches/src/main/kotlin/hoodles/morphe/patches/hellochinese/lesson/SkipOnFirstMistakePatch.kt
+++ b/patches/src/main/kotlin/hoodles/morphe/patches/hellochinese/lesson/SkipOnFirstMistakePatch.kt
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2026 Hoo-dles
+ * https://github.com/hoo-dles/morphe-patches
+ */
+
+package hoodles.morphe.patches.hellochinese.lesson
+
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.bytecodePatch
+import hoodles.morphe.patches.hellochinese.premium.enablePremiumPatch
+import hoodles.morphe.util.requireArm64
+
+@Suppress("unused")
+val skipOnFirstMistakePatch = bytecodePatch(
+    name = "Skip on first mistake",
+    description = "Shows both skip and continue buttons from the first mistake."
+) {
+    compatibleWith(Compatibility(
+        name = "HelloChinese",
+        packageName = "com.hellochinese",
+        appIconColor = 0xFFFFFF,
+        targets = listOf(AppTarget("7.11.0"))
+    ))
+
+    availability(requireArm64())
+
+    dependsOn(enablePremiumPatch)
+
+    execute {
+        // 1. Lower the wrong count threshold from 3 to 0 in V0().
+        //    This makes CheckPanel.m = true from the very first mistake.
+        val constIndex = SkipOnFirstMistakeFingerprint
+            .instructionMatches[6]
+            .index
+
+        SkipOnFirstMistakeFingerprint.method.replaceInstruction(
+            constIndex,
+            "const/4 v1, 0x0"
+        )
+
+        // 2. In CheckPanel.h(), change mContinueBtnLayout visibility from GONE (0x8)
+        //    to VISIBLE (0x0) so the continue button stays visible alongside skip.
+        //    The fingerprint matches: IGET_OBJECT, CONST_16, INVOKE_VIRTUAL,
+        //    IGET_OBJECT, CONST_4, INVOKE_VIRTUAL
+        //    Index 1 is the CONST_16 for mContinueBtnLayout (0x8 → 0x0).
+        val hMethod = CheckPanelHMethodFingerprint.method
+        val visIndex = CheckPanelHMethodFingerprint
+            .instructionMatches[1]
+            .index
+
+        hMethod.replaceInstruction(
+            visIndex,
+            "const/16 v1, 0x0"
+        )
+    }
+}


### PR DESCRIPTION
## Description

Adds the **Skip on first mistake** lesson patch from [morphe-patches-hellochinese](https://github.com/OmerKurdi79/morphe-patches-hellochinese) to the combined patch set.

This patch shows both skip and continue buttons from the first mistake in HelloChinese lessons, instead of waiting until 3 mistakes.

## What changed

- **`patches/src/main/kotlin/hoodles/morphe/patches/hellochinese/lesson/Fingerprints.kt`** — `SkipOnFirstMistakeFingerprint` (matches the V0() threshold constant) and `CheckPanelHMethodFingerprint` (matches the continue button visibility setter)
- **`patches/src/main/kotlin/hoodles/morphe/patches/hellochinese/lesson/SkipOnFirstMistakePatch.kt`** — the patch that lowers the threshold from 3→0 and makes the continue button visible alongside skip
- **`patches-list.json`** — added the new patch entry

## Notes

- The patch depends on the existing `Enable Premium` patch, which already handles the native integrity bypass (`libalg.so` hex patches + auth check). No duplication.
- Requires arm64-v8a, consistent with the premium patch.